### PR TITLE
通知にチャンネルオーナーの名前とアイコンを表示する

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -22,7 +22,7 @@ const setStorageData = (key, value) => {
 };
 
 const execNotification = request => {
-  const { liveTitle, authorName, message, iconUrl } = request;
+  const { liveTitle, authorName, message, iconUrl, ownerName, ownerIconUrl } = request;
   chrome.notifications.create(
     {
       type: 'basic',
@@ -30,6 +30,12 @@ const execNotification = request => {
       message,
       contextMessage: liveTitle,
       iconUrl,
+      buttons: [
+        {
+          title: ownerName,
+          iconUrl: ownerIconUrl,
+        }
+      ],
     },
     () => {},
   );

--- a/src/options.js
+++ b/src/options.js
@@ -41,6 +41,8 @@ document.querySelector('#notification-test-button').addEventListener('click', ()
       authorName: 'みんなよう見とる',
       message: 'テストだよ',
       iconUrl: chrome.runtime.getURL('images/icon128.png'),
+      ownerName: 'テスト',
+      ownerIconUrl: chrome.runtime.getURL('images/icon128.png'),
     },
     () => {},
   );


### PR DESCRIPTION
こんにちは、いつも複窓で楽しんでいます！

現状、通知元は配信タイトル名を表示していますが、通知欄の文字列長制限で非表示になる部分もあり目立たないケースがあると使っていて感じました。

そこでチャンネルオーナーの名前とアイコンを通知のbasicタイプのbutton部分として表示する修正を以下の通り提案してみます。

![2018-08-11_01h00_13](https://user-images.githubusercontent.com/1260365/43969255-70299536-9d04-11e8-9777-b54b0d3f08ba.png)

※ボタンに対するコールバックは登録していないため押しても何も起こりません。

また検討に際してYoutube Gamingにおけるチャンネルオーナーのアイコンはbackground-imageスタイルのurl()で指定されておりwatch.jsのselectorListではYouTubeとの差異が吸収出来ませんでした。

このため各サービスの通知要素を得るためのclass化を行っております。

もしよろしればフィードバックをお願いします。



