### PR TITLE
絵文字のサポート

### DIFF
--- a/src/watch.js
+++ b/src/watch.js
@@ -33,6 +33,23 @@ const fetchBlobUrl = async url => {
   return window.URL.createObjectURL(blob);
 };
 
+const getMessage = el => {
+  let messageString = '';
+
+  for (const child of el.childNodes) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      messageString += child.wholeText;
+    }
+    if (child.nodeType === Node.ELEMENT_NODE) {
+      if (child.nodeName.toLowerCase() === 'img' && typeof child.alt === 'string') {
+        messageString += child.alt;
+      }
+    }
+  }
+
+  return messageString;
+};
+
 const checkComment = async node => {
   if (node.nodeName.toLowerCase() !== 'yt-live-chat-text-message-renderer') {
     return;
@@ -41,7 +58,7 @@ const checkComment = async node => {
   const authorName = node.querySelector('#author-name').textContent;
   if (nameList.some(value => value === authorName.trim())) {
     const liveTitle = selector.getLiveTitle();
-    const message = node.querySelector('#message').textContent;
+    const message = getMessage(node.querySelector('#message'));
     const iconUrl = node.querySelector('#img').getAttribute('src');
     const iconLargeUrl = iconUrl.replace(/\/photo.jpg$/, '');
     const ownerName = selector.getOwnerName();


### PR DESCRIPTION
こんにちは。

チャットのメッセージに絵文字が含まれているときに、現状では通知にそれが表示されないので、表示されるようにするPRです。

絵文字は`img`要素としてメッセージに含まれており、その`alt`属性に対応するUnicode絵文字が入っているので、それで置き換えています。

![例1](https://user-images.githubusercontent.com/42849550/45256351-334c2d80-b3d0-11e8-942e-b2a6fcfacf30.png)

チャンネル独自の絵文字については、`alt`属性は`:コード:`という形になっており、これもそのまま表示するようにしています。

![例2](https://user-images.githubusercontent.com/42849550/45256396-e026aa80-b3d0-11e8-9dc1-d2cf4805b55f.png)