### PR TITLE
macでメッセージ全文を確認できるように

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -35,6 +35,10 @@ const execNotification = request => {
           title: ownerName,
           iconUrl: ownerIconUrl,
         },
+        {
+          title: message,
+          iconUrl,
+        },
       ],
     },
     () => {},

--- a/src/background.js
+++ b/src/background.js
@@ -21,28 +21,33 @@ const setStorageData = (key, value) => {
   });
 };
 
-const execNotification = request => {
+const isMac = () => {
+  return new Promise(resolve => {
+    chrome.runtime.getPlatformInfo(info => resolve(info.os === 'mac'));
+  });
+};
+
+const execNotification = async request => {
   const { liveTitle, authorName, message, iconUrl, ownerName, ownerIconUrl } = request;
-  chrome.notifications.create(
-    {
-      type: 'basic',
-      title: authorName,
-      message,
-      contextMessage: liveTitle,
-      iconUrl,
-      buttons: [
-        {
-          title: ownerName,
-          iconUrl: ownerIconUrl,
-        },
-        {
-          title: message,
-          iconUrl,
-        },
-      ],
-    },
-    () => {},
-  );
+  const option = {
+    type: 'basic',
+    title: authorName,
+    message,
+    contextMessage: liveTitle,
+    iconUrl,
+    buttons: [
+      {
+        title: ownerName,
+        iconUrl: ownerIconUrl,
+      },
+    ],
+  };
+  if (await isMac()) {
+    option.buttons.push({
+      title: message,
+    });
+  }
+  chrome.notifications.create(option, () => {});
 };
 
 chrome.runtime.onInstalled.addListener(async () => {


### PR DESCRIPTION
macでは通知枠の表示可能文字数が少なく、すぐ省略されてしまうので「もっと見る」押下で全文が確認できるようボタンの追加をしてみました。

### 対応後mac表示
![ss-mac](https://user-images.githubusercontent.com/1614258/58384914-f5596d00-8023-11e9-9eb1-94c5e57880be.png)

### 対応後win表示 (変更なし)
![ss-win](https://user-images.githubusercontent.com/1614258/58384918-fdb1a800-8023-11e9-9c09-5b9f0c9addf7.png)