### PR TITLE
fix #19 

### DIFF
--- a/src/watch.js
+++ b/src/watch.js
@@ -48,6 +48,9 @@ const checkComment = async node => {
   }
 
   const authorName = node.querySelector('#author-name').textContent.trim();
+  if (!authorName) {
+    return;
+  }
   if (nameList.some(value => value === authorName)) {
     const liveTitle = selector.getLiveTitle();
     const message = getMessage(node.querySelector('#message'));


### PR DESCRIPTION
名前を持ってないユーザなので、おそらく空文字チャンネル名。
チェック対象のチャンネル一覧内に空文字があるとヒットしてしまうようなので、事前に弾いておく。